### PR TITLE
Refactor to use Crystal's standard Digest abstraction.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,52 @@
 # xx_hash.cr
 
-Pure Crystal implementation of [xxHash](https://github.com/Cyan4973/xxHash) 32 and 64 bits.
+Pure Crystal implementation of [xxHash](https://xxhash.com) XXH32 and XXH64, 
+32-bit and 64-bit non-crypographic hash algorithms.
 
 ## Usage
+
+The lastest version of XXHash (`0.0.2`) now conforms to Cyrstal's standard
+[Digest](https://crystal-lang.org/api/Digest.html) abstraction.
+
+Here is a simple example of hasing a couple strings using the 32-bit hash function
+without a seed (defaults to `0`).
+
+```crystal
+  require "xxh32"
+
+  d = Digest::XXH32.new
+  d << "My String"
+  d.hexfinal
+
+  d.reset
+  d << "Another String"
+  d.hexfinal
+```
+
+Here is an example of hasing an entire file using the 64-bit function with a seed.
+
+```crystal
+
+  require "xxh64"
+
+  seed = 1234
+  
+  d = Digest::XXH64.new(seed)
+  d.file("somefile")
+  d.hexfinal
+```
+
+The digest for either of these can returned as an unsigned integer by using
+`to_u32` or `to_u64`, repsectively. Note, these two methods are not part of
+the standard Digest abstraction.
+
+See Crystal's [Digest](https://crystal-lang.org/api/Digest.html) class for further documentation.
+
+
+## Legacy Usage
+
+The old version of this API is deprecated but still available
+for the time-being.
 
 ```crystal
   require "xx_hash"

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Pure Crystal implementation of [xxHash](https://xxhash.com) XXH32 and XXH64,
 
 ## Usage
 
-The lastest version of XXHash (`0.0.2`) now conforms to Cyrstal's standard
+The lastest version of XXHash now conforms to Cyrstal's standard
 [Digest](https://crystal-lang.org/api/Digest.html) abstraction.
 
-Here is a simple example of hasing a couple strings using the 32-bit hash function
-without a seed (defaults to `0`).
+Here is a simple example of hashing a couple strings using the 32-bit hash
+function without a seed (defaults to `0`).
 
 ```crystal
   require "xxh32"
@@ -23,7 +23,8 @@ without a seed (defaults to `0`).
   d.hexfinal
 ```
 
-Here is an example of hasing an entire file using the 64-bit function with a seed.
+Here is an example of hasing an entire file using the 64-bit function
+with a seed.
 
 ```crystal
 
@@ -36,17 +37,17 @@ Here is an example of hasing an entire file using the 64-bit function with a see
   d.hexfinal
 ```
 
-The digest for either of these can returned as an unsigned integer by using
+The digest for either of these can be returned as an unsigned integer by using
 `to_u32` or `to_u64`, repsectively. Note, these two methods are not part of
 the standard Digest abstraction.
 
-See Crystal's [Digest](https://crystal-lang.org/api/Digest.html) class for further documentation.
+See Crystal's [Digest](https://crystal-lang.org/api/Digest.html) class for further
+documentation.
 
 
 ## Legacy Usage
 
-The old version of this API is deprecated but still available
-for the time-being.
+The old version of this API is deprecated but still available for the time-being.
 
 ```crystal
   require "xx_hash"
@@ -91,3 +92,18 @@ Add to your shard.yml:
     xx_hash:
       github: anykeyh/xx_hash
 ```
+
+## Contributors
+
+* [Yacine Petitprez](https://github.com/anykeyh) *Maintainer* Original author who ported XXH32 and XXH64 to Crystal.
+* [Tom Sawyer](https://github.com/trans) *Contributor* Refactored code to conform to Crystal's standard Digest abstraction.
+
+## Copyright
+
+Copyright (c) 2020 Yacine Petitprez
+
+*Based on original code by Yann Collet.*
+Copyright (c) 2012-2021 Yann Collet
+BSD 2-Clause License (https://www.opensource.org/licenses/bsd-license.php)
+
+

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,2 +1,1 @@
 require "spec"
-require "../src/xx_hash"

--- a/spec/xx_hash_spec.cr
+++ b/spec/xx_hash_spec.cr
@@ -1,30 +1,30 @@
 require "./spec_helper"
-require "../src/xx_hash"
+require "../spec/xx_hash"
 
 CASES = [
   # Case A > 32 characters fill buff for 32 and 64 bits versions
-  {"Nobody inspects the spammish repetition", 0, 0xe2293b2f, 0xfbcea83c8a378bf1},
-  {"Nobody inspects the spammish repetition", 1234, 0x298ce4e5, 0x55e30cd248a5419f}, #https://asecuritysite.com/encryption/xxHash
+  {"Nobody inspects the spammish repetition", 0, 0xe2293b2f, 0xfbcea83c8a378bf1_u64},
+  {"Nobody inspects the spammish repetition", 1234, 0x298ce4e5, 0x55e30cd248a5419f_u64}, #https://asecuritysite.com/encryption/xxHash
 
   # Case B < 16 characters no buffer filled
-  {"small", 0, 0x8e52cd6a, 0xa8ce38f99756b7b3},
-  {"small", 1234, 0x1acf736b, 0x3709561c2893a1d0},
+  {"small", 0, 0x8e52cd6a, 0xa8ce38f99756b7b3_u64},
+  {"small", 1234, 0x1acf736b, 0x3709561c2893a1d0_u64},
 
   # Case C empty string
-  {"", 0, 0x02cc5d05, 0xef46db3751d8e999},
-  {"", 1234, 0xb625a4db, 0xe80dc1ad52e210e4},
+  {"", 0, 0x02cc5d05, 0xef46db3751d8e999_u64},
+  {"", 1234, 0xb625a4db, 0xe80dc1ad52e210e4_u64},
 
   # Case D a long string
   {"Cras dignissim sem sed euismod pretium. Sed facilisis diam dolor. Curabitur turpis ex, euismod vel est ut, pharetra condimentum lacus. Sed eget aliquet tellus, in vestibulum tellus. Duis tellus tortor, porttitor nec arcu quis, tristique lobortis neque. Cras pharetra, sem in vestibulum mollis, dui elit vulputate nulla, eget egestas elit tellus in leo. Proin fermentum eros nec dolor dictum rutrum. Curabitur quam lacus, posuere non turpis sit amet, gravida molestie augue. Vestibulum nec venenatis purus. Pellentesque vestibulum nunc ut libero pharetra, ut egestas odio hendrerit. Duis euismod ipsum leo, id lacinia massa ultricies eu. In congue venenatis tristique. In ullamcorper augue quam, id pretium ex dictum id. Morbi blandit eleifend neque, quis pulvinar neque dignissim at. Integer sodales diam ac metus maximus, sed cursus risus commodo.", 0, 0xbc702865, 0x27b8f6a015650fb5 },
   {"Cras dignissim sem sed euismod pretium. Sed facilisis diam dolor. Curabitur turpis ex, euismod vel est ut, pharetra condimentum lacus. Sed eget aliquet tellus, in vestibulum tellus. Duis tellus tortor, porttitor nec arcu quis, tristique lobortis neque. Cras pharetra, sem in vestibulum mollis, dui elit vulputate nulla, eget egestas elit tellus in leo. Proin fermentum eros nec dolor dictum rutrum. Curabitur quam lacus, posuere non turpis sit amet, gravida molestie augue. Vestibulum nec venenatis purus. Pellentesque vestibulum nunc ut libero pharetra, ut egestas odio hendrerit. Duis euismod ipsum leo, id lacinia massa ultricies eu. In congue venenatis tristique. In ullamcorper augue quam, id pretium ex dictum id. Morbi blandit eleifend neque, quis pulvinar neque dignissim at. Integer sodales diam ac metus maximus, sed cursus risus commodo.", 1234, 0x0f8da06d, 0x1cf0478f6499f2ae },
 
   # Case E exactly 16 bytes
-  {"1234567890abcdef", 0, 0x17fddd25, 0x1b576a0cfae1707e },
-  {"1234567890abcdef", 1234, 0x3c299461, 0x0a176fa30c839a45 },
+  {"1234567890abcdef", 0, 0x17fddd25, 0x1b576a0cfae1707e_u64 },
+  {"1234567890abcdef", 1234, 0x3c299461, 0x0a176fa30c839a45_u64 },
 
   # Case F exactly 32 bytes
-  {"1234567890abcdef1234567890abcdef", 0, 0xf11e8d8c, 0xc1bf3856a435f3ec },
-  {"1234567890abcdef1234567890abcdef", 1234, 0x80105224, 0x3e450250700580a0 },
+  {"1234567890abcdef1234567890abcdef", 0, 0xf11e8d8c, 0xc1bf3856a435f3ec_u64 },
+  {"1234567890abcdef1234567890abcdef", 1234, 0x80105224, 0x3e450250700580a0_u64 },
 
 ]
 module XXHashSpec

--- a/spec/xx_hash_spec.cr
+++ b/spec/xx_hash_spec.cr
@@ -1,4 +1,5 @@
 require "./spec_helper"
+require "../src/xx_hash"
 
 CASES = [
   # Case A > 32 characters fill buff for 32 and 64 bits versions

--- a/spec/xxh32_spec.cr
+++ b/spec/xxh32_spec.cr
@@ -1,0 +1,145 @@
+require "./spec_helper"
+require "../src/digest/xxh32"
+
+module XXH32Spec
+  # See https://asecuritysite.com/encryption/xxHash
+  
+  # Case A > 32 characters fill buffer
+  
+  it "Returns digest for filled buffer" do
+    data = "Nobody inspects the spammish repetition"
+    resl = 0xe2293b2f_u32
+
+    computed32 = Digest::XXH32.new
+    computed32 << data
+    computed32.to_u32.should eq resl
+    computed32.reset
+  end
+
+  it "Returns correct digest for filled buffer given a seed" do
+    data = "Nobody inspects the spammish repetition"
+    seed = 1234
+    resl = 0x298ce4e5_u32 
+
+    computed32 = Digest::XXH32.new(seed)
+    computed32 << data
+    computed32.to_u32.should eq resl
+    computed32.reset
+   end
+  
+  # Case B < 16 characters no buffer filled
+  
+  it "Returns correct digest when buffer is not full" do
+    data = "small"
+    resl = 0x8e52cd6a_u32
+    
+    computed32 = Digest::XXH32.new
+    computed32 << data
+    computed32.to_u32.should eq resl
+    computed32.reset
+  end
+  
+  it "Returns correct digest when buffer is not full given a seed" do
+    data = "small"
+    seed = 1234
+    resl = 0x1acf736b_u32
+
+    computed32 = Digest::XXH32.new(seed)
+    computed32 << data
+    computed32.to_u32.should eq resl
+    computed32.reset
+  end
+  
+  # Case C empty string
+
+  it "Returns correct digest for empty string" do
+    data = ""
+    resl = 0x02cc5d05_u32
+
+    computed32 = Digest::XXH32.new
+    computed32 << data
+    computed32.to_u32.should eq resl
+    computed32.reset
+   end
+
+  it "return correct digest for empty string given a seed" do
+    data = ""
+    seed = 1234
+    resl = 0xb625a4db_u32
+
+    computed32 = Digest::XXH32.new(seed)
+    computed32 << data
+    computed32.to_u32.should eq resl
+    computed32.reset
+   end
+
+  # Case D a long string
+
+  it "Returns correct digest for long string" do
+    data = "Cras dignissim sem sed euismod pretium. Sed facilisis diam dolor. Curabitur turpis ex, euismod vel est ut, pharetra condimentum lacus. Sed eget aliquet tellus, in vestibulum tellus. Duis tellus tortor, porttitor nec arcu quis, tristique lobortis neque. Cras pharetra, sem in vestibulum mollis, dui elit vulputate nulla, eget egestas elit tellus in leo. Proin fermentum eros nec dolor dictum rutrum. Curabitur quam lacus, posuere non turpis sit amet, gravida molestie augue. Vestibulum nec venenatis purus. Pellentesque vestibulum nunc ut libero pharetra, ut egestas odio hendrerit. Duis euismod ipsum leo, id lacinia massa ultricies eu. In congue venenatis tristique. In ullamcorper augue quam, id pretium ex dictum id. Morbi blandit eleifend neque, quis pulvinar neque dignissim at. Integer sodales diam ac metus maximus, sed cursus risus commodo."
+    resl = 0xbc702865_u32
+
+    computed32 = Digest::XXH32.new
+    computed32 << data
+    computed32.to_u32.should eq resl
+    computed32.reset
+   end
+
+  it "Returns correct digest for long string given a seed" do
+    data = "Cras dignissim sem sed euismod pretium. Sed facilisis diam dolor. Curabitur turpis ex, euismod vel est ut, pharetra condimentum lacus. Sed eget aliquet tellus, in vestibulum tellus. Duis tellus tortor, porttitor nec arcu quis, tristique lobortis neque. Cras pharetra, sem in vestibulum mollis, dui elit vulputate nulla, eget egestas elit tellus in leo. Proin fermentum eros nec dolor dictum rutrum. Curabitur quam lacus, posuere non turpis sit amet, gravida molestie augue. Vestibulum nec venenatis purus. Pellentesque vestibulum nunc ut libero pharetra, ut egestas odio hendrerit. Duis euismod ipsum leo, id lacinia massa ultricies eu. In congue venenatis tristique. In ullamcorper augue quam, id pretium ex dictum id. Morbi blandit eleifend neque, quis pulvinar neque dignissim at. Integer sodales diam ac metus maximus, sed cursus risus commodo."
+    seed = 1234
+    resl = 0x0f8da06d_u32
+
+    computed32 = Digest::XXH32.new(seed)
+    computed32 << data
+    computed32.to_u32.should eq resl
+    computed32.reset
+   end
+  
+  # Case E exactly 16 bytes
+
+  it "Returns correct digest for exactly 16 bytes" do  
+    data = "1234567890abcdef"
+    resl = 0x17fddd25_u32
+
+    computed32 = Digest::XXH32.new
+    computed32 << data
+    computed32.to_u32.should eq resl
+    computed32.reset
+  end
+
+  it "Retuns correct digest for exactly 16 bytes given a seed" do
+    data = "1234567890abcdef"
+    seed = 1234
+    resl = 0x3c299461
+
+    computed32 = Digest::XXH32.new(seed)
+    computed32 << data
+    computed32.to_u32.should eq resl
+    computed32.reset
+   end
+  
+  # Case F exactly 32 bytes
+
+  it "Returns the correct digest for exactly 32 bytes" do
+    data = "1234567890abcdef1234567890abcdef"
+    resl = 0xf11e8d8c_u32
+
+    computed32 = Digest::XXH32.new
+    computed32 << data
+    computed32.to_u32.should eq resl
+    computed32.reset
+   end
+
+  it "Returns to correct digest for exactly 32 bytes given a seed" do
+    data = "1234567890abcdef1234567890abcdef"
+    seed = 1234
+    resl = 0x80105224_u32
+
+    computed32 = Digest::XXH32.new(seed)
+    computed32 << data
+    computed32.to_u32.should eq resl
+    computed32.reset
+   end
+
+end

--- a/spec/xxh64_spec.cr
+++ b/spec/xxh64_spec.cr
@@ -1,0 +1,145 @@
+require "./spec_helper"
+require "../src/digest/xxh64"
+
+module XXH64Spec
+  # See https://asecuritysite.com/encryption/xxHash
+
+  # Case A > 32 characters fill buffer
+
+  it "Returns digest for filled buffer" do
+    data = "Nobody inspects the spammish repetition"
+    resl = 0xfbcea83c8a378bf1_u64
+
+    computed64 = Digest::XXH64.new
+    computed64 << data
+    computed64.to_u64.should eq resl
+    computed64.reset
+  end 
+
+  it "Returns correct digest for filled buffer given a seed" do
+    data = "Nobody inspects the spammish repetition"
+    seed = 1234
+    resl = 0x55e30cd248a5419f_u64
+
+    computed64 = Digest::XXH64.new(seed)
+    computed64 << data
+    computed64.to_u64.should eq resl
+    computed64.reset
+  end
+
+  # Case B < 32 chracters no buffer filled
+
+  it "Returns correct digest when buffer is not filled" do
+    data = "small"
+    resl = 0xa8ce38f99756b7b3_u64
+
+    computed64 = Digest::XXH64.new
+    computed64 << data
+    computed64.to_u64.should eq resl
+    computed64.reset
+  end
+
+  it "Returns correct digest when buffer is not filled given a seed" do
+    data = "small"
+    seed = 1234
+    resl = 0x3709561c2893a1d0_u64
+
+    computed64 = Digest::XXH64.new(seed)
+    computed64 << data
+    computed64.to_u64.should eq resl
+    computed64.reset
+  end
+
+  # Case C - empty string
+
+  it "Returns correct digest for empty string" do
+    data = ""
+    resl = 0xef46db3751d8e999_u64
+
+    computed64 = Digest::XXH64.new
+    computed64 << data
+    computed64.to_u64.should eq resl
+    computed64.reset
+  end
+
+  it "Returns correct digest for empty string give a seed" do
+    data = ""
+    seed = 1234
+    resl = 0xe80dc1ad52e210e4_u64
+
+    computed64 = Digest::XXH64.new(seed)
+    computed64 << data
+    computed64.to_u64.should eq resl
+    computed64.reset
+  end
+
+  # Case D - a long string
+
+  it "Returns correct digest for long string" do
+    data = "Cras dignissim sem sed euismod pretium. Sed facilisis diam dolor. Curabitur turpis ex, euismod vel est ut, pharetra condimentum lacus. Sed eget aliquet tellus, in vestibulum tellus. Duis tellus tortor, porttitor nec arcu quis, tristique lobortis neque. Cras pharetra, sem in vestibulum mollis, dui elit vulputate nulla, eget egestas elit tellus in leo. Proin fermentum eros nec dolor dictum rutrum. Curabitur quam lacus, posuere non turpis sit amet, gravida molestie augue. Vestibulum nec venenatis purus. Pellentesque vestibulum nunc ut libero pharetra, ut egestas odio hendrerit. Duis euismod ipsum leo, id lacinia massa ultricies eu. In congue venenatis tristique. In ullamcorper augue quam, id pretium ex dictum id. Morbi blandit eleifend neque, quis pulvinar neque dignissim at. Integer sodales diam ac metus maximus, sed cursus risus commodo."
+    resl = 0x27b8f6a015650fb5_u64
+
+    computed64 = Digest::XXH64.new
+    computed64 << data
+    computed64.to_u64.should eq resl
+    computed64.reset
+  end
+
+  it "Returns correct digest for long string given a seed" do
+    data = "Cras dignissim sem sed euismod pretium. Sed facilisis diam dolor. Curabitur turpis ex, euismod vel est ut, pharetra condimentum lacus. Sed eget aliquet tellus, in vestibulum tellus. Duis tellus tortor, porttitor nec arcu quis, tristique lobortis neque. Cras pharetra, sem in vestibulum mollis, dui elit vulputate nulla, eget egestas elit tellus in leo. Proin fermentum eros nec dolor dictum rutrum. Curabitur quam lacus, posuere non turpis sit amet, gravida molestie augue. Vestibulum nec venenatis purus. Pellentesque vestibulum nunc ut libero pharetra, ut egestas odio hendrerit. Duis euismod ipsum leo, id lacinia massa ultricies eu. In congue venenatis tristique. In ullamcorper augue quam, id pretium ex dictum id. Morbi blandit eleifend neque, quis pulvinar neque dignissim at. Integer sodales diam ac metus maximus, sed cursus risus commodo."
+    seed = 1234
+    resl = 0x1cf0478f6499f2ae_u64
+
+    computed64 = Digest::XXH64.new(seed)
+    computed64 << data
+    computed64.to_u64.should eq resl
+    computed64.reset
+  end
+
+  # Case E - exactly 16 bytes
+
+  it "Returns correct digest for exactly 16 bytes" do
+    data = "1234567890abcdef"
+    resl = 0x1b576a0cfae1707e_u64
+
+    computed64 = Digest::XXH64.new
+    computed64 << data
+    computed64.to_u64.should eq resl
+    computed64.reset
+  end
+
+  it "Returns correct digest for exactly 16 bytes give a seed" do
+    data = "1234567890abcdef"
+    seed = 1234
+    resl = 0x0a176fa30c839a45_u64
+
+    computed64 = Digest::XXH64.new(seed)
+    computed64 << data
+    computed64.to_u64.should eq resl
+    computed64.reset
+  end
+
+  # Case F - exactly 32 bytes
+
+  it "Returns correct digest for exactly 32 bytes" do
+    data = "1234567890abcdef1234567890abcdef"
+    resl = 0xc1bf3856a435f3ec_u64
+
+    computed64 = Digest::XXH64.new
+    computed64 << data
+    computed64.to_u64.should eq resl
+    computed64.reset
+  end
+
+  it "Returns correct digest for exactly 32 bytes give a seed" do
+    data = "1234567890abcdef1234567890abcdef"
+    seed = 1234
+    resl = 0x3e450250700580a0_u64
+
+    computed64 = Digest::XXH64.new(seed)
+    computed64 << data
+    computed64.to_u64.should eq resl
+    computed64.reset
+  end
+
+end

--- a/src/digest/xxh32.cr
+++ b/src/digest/xxh32.cr
@@ -1,0 +1,150 @@
+require "digest"
+
+class Digest::XXH32 < ::Digest
+  extend ClassMethods
+
+  private P1 = 2654435761_u32
+  private P2 = 2246822519_u32
+  private P3 = 3266489917_u32
+  private P4 = 668265263_u32
+  private P5 = 374761393_u32
+
+  @seed   : UInt32 = 0
+  @digest : UInt32 = 0
+  
+  @len    : UInt32 = 0
+  @buf    : Slice(UInt8)
+  
+  @v0 : UInt32 = 0
+  @v1 : UInt32 = 0
+  @v2 : UInt32 = 0
+  @v3 : UInt32 = 0
+
+  def initialize(seed = 0)
+    @seed = UInt32.new(seed)
+    @digest = 0
+    
+    sp2 = @seed &+ P2
+
+    @v0 = (sp2 &+ P1)
+    @v1 = sp2
+    @v2 = (@seed)
+    @v3 = (@seed &- P1)
+
+    @len = 0
+    @buf = Bytes.new(0)
+  end
+
+  # Store the output digest of #digest_size bytes in dst.
+  def final_impl(dst : Bytes) : Nil
+    @digest = digest_hash()
+
+    dst[0] = (@digest >> 24).to_u8!
+    dst[1] = (@digest >> 16).to_u8!
+    dst[2] = (@digest >> 8).to_u8!
+    dst[3] = (@digest).to_u8!
+  end
+
+  # Resets the object to it's initial state,
+  # so a new digest can be generated.
+  private def reset_impl() : Nil
+    sp2 = @seed &+ P2
+
+    @v0 = (sp2 &+ P1)
+    @v1 = sp2
+    @v2 = (@seed)
+    @v3 = (@seed &- P1)
+
+    @len = 0
+    @buf = Bytes.new(0)
+  end
+
+  # Returns the digest output size in bytes.
+  # XXH32 is a 32-bit digest, so the size is 4 bytes.
+  def digest_size() : Int32
+    4
+  end
+
+  # Incremental hashing.
+  #
+  # TODO: Use modulo.
+  private def update_impl(data : Bytes) : Nil
+    data = @buf + data
+
+    loop do
+      if data.size >= 16
+        slice16 = data[0,16]
+        data += 16
+        @len += 16
+        {% for i in 0..3 %}
+          v = @v{{i}} &+ b2i32({{i*4}}, slice16) &* P2
+          v = rotl(v, 13) &* P1
+          @v{{i}} = v
+        {% end %}
+      else
+        @buf = data
+        break
+      end
+    end
+  end
+
+  #
+
+  private def digest_hash()
+    buf = @buf
+    
+    if @len >= 16
+      hash = rotl(@v0, 1)  &+
+             rotl(@v1, 7)  &+
+             rotl(@v2, 12) &+
+             rotl(@v3, 18)
+    else
+      hash = @seed &+ P5
+    end
+
+    @len += buf.size
+
+    ptr = buf.size
+
+    hash = hash &+ @len
+
+    p = 0
+    while p <= (ptr - 4)
+      mem = b2i32(p, buf)
+      hash = hash &+ mem &* P3
+      hash = rotl(hash, 17) &* P4
+      p += 4
+    end
+
+    while p < ptr
+      hash = hash &+ buf[p].to_u32 &* P5
+      hash = rotl(hash, 11) &* P1
+      p += 1
+    end
+
+    hash ^= hash >> 15
+    hash = hash &* P2
+    hash ^= hash >> 13
+    hash = hash &* P3
+    hash ^= hash >> 16
+
+    hash
+  end
+
+  # Get the digest as an originary unsigned integer, rather
+  # than a collection of bytes.
+  def to_u32
+   digest_hash
+  end
+
+  private def b2i32(idx, bytes)
+    (bytes.to_unsafe + idx).unsafe_as(Pointer(UInt32)).value
+  end
+
+  # apply byte rotation for a 32 bits buffer
+  private def rotl(buffer, offset)
+    (buffer << offset) | (buffer >> (32 - offset))
+  end
+
+end  
+

--- a/src/digest/xxh64.cr
+++ b/src/digest/xxh64.cr
@@ -1,0 +1,178 @@
+require "digest"
+
+class Digest::XXH64 < ::Digest
+  extend ClassMethods
+
+  private P1 = 11400714785074694791_u64
+  private P2 = 14029467366897019727_u64
+  private P3 = 1609587929392839161_u64
+  private P4 = 9650029242287828579_u64
+  private P5 = 2870177450012600261_u64
+
+  @seed   : UInt64
+  @digest : UInt64
+
+  @len : UInt32 = 0
+  @buf : Slice(UInt8)
+  
+  @v0 : UInt64
+  @v1 : UInt64
+  @v2 : UInt64
+  @v3 : UInt64
+  
+  def initialize(seed = 0)
+    @seed = UInt64.new(seed)
+    @digest = 0
+    
+    sp2 = @seed &+ P2
+    @v0 = (sp2 &+ P1)
+    @v1 =  sp2
+    @v2 = (@seed)
+    @v3 = (@seed &- P1)
+
+    @len = 0
+    @buf = Bytes.new(0)
+  end
+
+  # Stores the output digest of #digest_size bytes in dst.
+  def final_impl(dst : Bytes) : Nil
+    @digest = digest_hash()
+
+    dst[0] = (@digest >> 56).to_u8!
+    dst[1] = (@digest >> 48).to_u8!
+    dst[2] = (@digest >> 40).to_u8!
+    dst[3] = (@digest >> 32).to_u8!
+    dst[4] = (@digest >> 24).to_u8!
+    dst[5] = (@digest >> 16).to_u8!
+    dst[6] = (@digest >> 8).to_u8!
+    dst[7] = (@digest).to_u8!
+  end
+
+  # Resets the object to it's initial state,
+  # so a new digest can be generated.
+  private def reset_impl() : Nil
+    sp2 = @seed &+ P2
+    @v0 = (sp2 &+ P1)
+    @v1 =  sp2
+    @v2 = (@seed)
+    @v3 = (@seed &- P1)
+
+    @len = 0
+    @buf = Bytes.new(0)
+  end
+
+  # Returns the digest output size in bytes.
+  # XXH64 is a 64-bit digest, so the size is 8 bytes.
+  def digest_size() : Int32
+    8
+  end
+  
+  # Incremental hashing.
+  #
+  # TODO: This could go a little faster by using module division
+  # of 32 to determine how many 32 bytes segments to loop over,
+  # instead of using an `if` check each cycle.
+  private def update_impl(data : Bytes) : Nil
+    data = @buf + data
+    
+    loop do
+      if data.size >= 32
+        slice32 = data[0,32] # get the first 32 bytes
+        data += 32           # everything after 32 bytes
+        @len += 32
+        {% for i in 0..3 %}
+          v = @v{{i}} &+ b2i64({{i*8}}, slice32) &* P2
+          v = rotl(v, 31) &* P1
+          @v{{i}} = v
+        {% end %}
+      else
+        @buf = data
+        break
+      end
+    end
+  end
+
+  # The final_imp method calls this to get the final digest as a UInt64,
+  # which it then turns into Bytes.
+  #
+  # NOTE: I would think this would be a private method, byt Cyrstal raises
+  #       and error if it is.
+  
+  private def digest_hash()
+    buf = @buf
+    
+    if @len >= 32
+      hash = rotl(@v0, 1)  &+
+             rotl(@v1, 7)  &+
+             rotl(@v2, 12) &+
+             rotl(@v3, 18)
+
+      {% for i in 0..3 %}
+        v = rotl(@v{{i}} &* P2, 31)
+        hash ^= v &* P1
+        hash = hash &* P1 &+ P4
+      {% end %}
+    else
+      hash = @seed &+ P5
+    end
+
+    @len += buf.size
+
+    ptr = buf.size
+    
+    hash = hash &+ @len
+
+    p = 0
+    while p <= (ptr - 8)
+      mem = rotl(b2i64(p, buf) &* P2, 31)
+
+      hash ^= mem &* P1
+      hash = rotl(hash, 27) &* P1 &+ P4
+
+      p += 8
+    end
+
+    while p <= (ptr - 4)
+      mem = b2i32(p, buf)
+
+      hash ^= mem &* P1
+      hash = rotl(hash, 23) &* P2 &+ P3
+
+      p += 4
+    end
+
+    while p < ptr
+      hash ^= buf[p].to_u64 &* P5
+      hash = rotl(hash, 11) &* P1
+      p += 1
+    end
+
+    hash ^= hash >> 33
+    hash = hash &* P2
+    hash ^= hash >> 29
+    hash = hash &* P3
+    hash ^= hash >> 32
+
+    hash
+  end
+
+  # Get the digest as an ordinary integer, rather than
+  # a colleciton of bytes.
+  def to_u64
+    digest_hash
+  end
+
+  private def b2i64(idx, buff)
+    (buff.to_unsafe + idx).unsafe_as(Pointer(UInt64)).value
+  end
+
+  private def b2i32(idx, buff)
+    (buff.to_unsafe + idx).unsafe_as(Pointer(UInt32)).value.to_u64
+  end
+
+  # apply byte rotation for a 32 bits buffer
+  private def rotl(buffer, offset)
+    (buffer << offset) | (buffer >> (64 - offset))
+  end
+
+end


### PR DESCRIPTION
As promised, here is the refactored version to use Crystal's standard Digest abstraction. Over all it went smoothly, though it took a little more reworking than I originally expected. 

Just a few things to note:

1. I left the old code as is. I didn't want to break anyone else's code that might be depending on it. But you'll probably want to add warnings to the old code so you can phase it out as some point in the future.
2. Wasn't sure how you wanted to handle the VERSION constant with the new modules. I just added VERSION to both `digest/xxh32.cr` and `digest/xxh64.cr`. Notice I stuck close to the Crystal's own file organization and the official names of these hash algorithms.
3. No doubt there's still room for improvements to the code. But I felt I reached a good checkpoint.
4. Eventually more tests should be added to cover the Digest abstractions to make sure all is working just as expected.
5. I was thinking... maybe, if XXH3 and XXH128 get implemented (which would be awesome!), Crystal might adopt this as part of its standard library -- XXHash seems to be becoming rather popular.
6. Lastly, maybe the license should be changed to BSD-2 since that is what the original XXHash library is? I'm not sure how that works. Just a thought.

HTH!

